### PR TITLE
Set default to irc.libera.chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 See [action.yml](./action.yml) For comprehensive list of options.
  
-Example, send notifications to freenode IRC channel:
+Example, send notifications to Libera Chat IRC channel:
 
 ```yaml
 name: "Push Notification"

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'Andrew Wason'
 inputs:
   server:
     description: 'IRC server'
-    default: 'chat.freenode.net'
+    default: 'irc.libera.chat'
     required: true
   port:
     description: 'IRC server port'

--- a/notify_irc.py
+++ b/notify_irc.py
@@ -50,7 +50,7 @@ class NotifyIRC(pydle.Client):
 
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--server", default="chat.freenode.net")
+    parser.add_argument("--server", default="irc.libera.chat")
     parser.add_argument("-p", "--port", default=6667, type=int)
     parser.add_argument("--password", default=None, help="Optional server password")
     parser.add_argument("--nickname", default="github-notify")


### PR DESCRIPTION
Because Freenode is basically dead. And recently all channels and nicks were dropped there making Libera larger.