### PR TITLE
README: specify server, and fix PR `html_url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ jobs:
         if: github.event_name == 'push'
         with:
           channel: "#mychannel"
+          server: "irc.libera.chat"
           nickname: my-github-notifier
           message: |
             ${{ github.actor }} pushed ${{ github.event.ref }} ${{ github.event.compare }}
@@ -28,14 +29,16 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           channel: "#mychannel"
+          server: "irc.libera.chat"
           nickname: my-github-notifier
           message: |
-            ${{ github.actor }} opened PR ${{ github.event.html_url }}
+            ${{ github.actor }} opened PR ${{ github.event.pull_request.html_url }}
       - name: irc tag created
         uses: rectalogic/notify-irc@v1
         if: github.event_name == 'create' && github.event.ref_type == 'tag'
         with:
           channel: "#mychannel"
+          server: "irc.libera.chat"          
           nickname: my-github-notifier
           message: |
             ${{ github.actor }} tagged ${{ github.repository }} ${{ github.event.ref }}


### PR DESCRIPTION
- specify server (as most users will not be aware that now the default is `irc.libera.chat`)
- fix empty PR url in notice ( change to the correct `github.event.pull_request.html_url` )
  - (without this fix, the notice states "user opened PR "  with no link)